### PR TITLE
Fix TEMP_CELSIUS deprecation warning

### DIFF
--- a/custom_components/metar/sensor.py
+++ b/custom_components/metar/sensor.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_TIME, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_TIME, CONF_MONITORED_CONDITIONS, UnitOfTemperature.CELSIUS
 try:
     from urllib2 import urlopen
 except:


### PR DESCRIPTION
import UnitOfTemperature.CELSIUS instead of TEMP_CELSIUS (deprecated)